### PR TITLE
Make fromHaveData pattern matching exhaustive and throw exception in a similar way to Data.Maybe fromJust

### DIFF
--- a/Data/Possible.hs
+++ b/Data/Possible.hs
@@ -44,6 +44,8 @@ instance  Monad Possible where
     fail _              = HaveNull
 
 fromHaveData :: Possible a -> a
+fromHaveData HaveNull     = error "Maybe.fromHaveData: HaveNull"
+fromHaveData MissingData  = error "Maybe.fromHaveData: MissingData"
 fromHaveData (HaveData a) = a
 
 possible :: b -> b -> (a -> b) -> Possible a -> b


### PR DESCRIPTION
This is a simple change to make fromHaveData pattern matching exhaustive and throw exception in a similar way to Data.Maybe fromJust, for consistency.

Reference: http://hackage.haskell.org/package/base-4.7.0.2/docs/src/Data-Maybe.html#fromJust
